### PR TITLE
change gitea key server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ gitea_version: '1.13.6'
 gitea_version_check: true
 gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 gitea_gpg_key: '7C9E68152594688862D62AF62D9AE806EC1592E2'
-gitea_gpg_server: 'hkp://keyserver.ubuntu.com:80'
+gitea_gpg_server: 'hkp://keys.openpgp.org'
 gitea_backup_on_upgrade: false
 gitea_backup_location: "{{ gitea_home }}/backups/"
 submodules_versioncheck: false


### PR DESCRIPTION
based on https://docs.gitea.io/en-us/install-from-binary/ gitea is recomending keys.openpgp.org as key server.

Thanks to @DC7IA for noticing it!