### PR TITLE
fail2ban only if installed

### DIFF
--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -8,6 +8,7 @@
     group: root
     mode: 0444
   notify: systemctl restart fail2ban
+  when: 'fail2ban' in ansible_facts.packages
 
 - name: Install fail2ban jail
   become: true
@@ -18,3 +19,4 @@
     group: root
     mode: 0444
   notify: systemctl restart fail2ban
+  when: 'fail2ban' in ansible_facts.packages  

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -20,3 +20,9 @@
     mode: 0444
   notify: systemctl restart fail2ban
   when: "'fail2ban' in ansible_facts.packages"
+
+- name: warn if fail2ban is not installed
+  ansible.builtin.fail:
+    msg: "the package fail2ban is not installed. no fail2ban filters deployed."
+  when: "'fail2ban' not in ansible_facts.packages"
+  ignore_errors: true

--- a/tasks/fail2ban.yml
+++ b/tasks/fail2ban.yml
@@ -8,7 +8,7 @@
     group: root
     mode: 0444
   notify: systemctl restart fail2ban
-  when: 'fail2ban' in ansible_facts.packages
+  when: "'fail2ban' in ansible_facts.packages"
 
 - name: Install fail2ban jail
   become: true
@@ -19,4 +19,4 @@
     group: root
     mode: 0444
   notify: systemctl restart fail2ban
-  when: 'fail2ban' in ansible_facts.packages  
+  when: "'fail2ban' in ansible_facts.packages"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: perform optional versionscheck
   ansible.builtin.include_tasks: versioncheck.yml
   when: submodules_versioncheck|bool
-  
+
 - name: Gather installed packages for checks later on
   ansible.builtin.package_facts:
     manager: auto

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: perform optional versionscheck
   ansible.builtin.include_tasks: versioncheck.yml
   when: submodules_versioncheck|bool
+  
+- name: Gather installed packages for checks later on
+  ansible.builtin.package_facts:
+    manager: auto
 
 - name: Gather variables for each operating system
   ansible.builtin.include_vars: "{{ lookup('first_found', gitea_variables) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,5 +20,5 @@ gitea_variables:
   paths:
     - 'vars'
 
-playbook_version_number: 8  # should be int
+playbook_version_number: 9  # should be int
 playbook_version_path: 'do1jlr.gitea.version'


### PR DESCRIPTION
If fail2ban is not installed on remote the role will fail. 

I have added a check to only run fail2ban if it is installed on the remote machine (not tested yet). 

Possible problem: There is no message to the users at the moment and they won't know that fail2ban hasn't been configured (because not installed). 