### PR TITLE
Quote mailer password

### DIFF
--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -116,7 +116,7 @@ SKIP_VERIFY        = {{ gitea_mailer_skip_verify | ternary('true', 'false') }}
 IS_TLS_ENABLED     = {{ gitea_mailer_tls_enabled | ternary('true', 'false') }}
 FROM               = {{ gitea_mailer_from }}
 USER               = {{ gitea_mailer_user }}
-PASSWD             = {{ gitea_mailer_password }}
+PASSWD             = `{{ gitea_mailer_password }}`
 SUBJECT_PREFIX     = {{ gitea_subject_prefix }}
 MAILER_TYPE        = {{ gitea_mailer_type }}
 {{ gitea_mailer_extra_config }}


### PR DESCRIPTION
Quoting of the password allows for special characters, see https://docs.gitea.io/en-us/email-setup/

Without that, the authentication at the mail server fails.