### PR TITLE
Add 'latest' version to automatically download the latest gitea release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ The following code has been tested with Debian 8, it should work on Ubuntu as we
 -----------
 Here is a deeper insight into the variables of this gitea role. For the exact function of some variables and the possibility to add more options we recommend a look at the config cheat sheet.  For the exact function of some variables and the possibility to add more options we recommend a look at this [config cheat sheet](https://docs.gitea.io/en-us/config-cheat-sheet/).
 
-### gitea version
+### gitea update
+To determine which gitea version to install, you can choose between two variants.
+Either you define exactly which release you install. Or you use the option ``latest`` to always install the latest release from the [gitea releases](https://github.com/go-gitea/gitea/releases/latest).
+
+### gitea update
 | variable name | default value | description |
 | ------------- | ------------- | ----------- |
-| `gitea_version` | *(see [defaults/main.yml](defaults/main.yml#L3))* | The gitea version this role shoud install |
+| `gitea_version` | **WILL CHANGE SOON** | Define either the exact release to install or use ``latest`` to install the latest release. |
 | `gitea_version_check` | `true` | Check if installed version != `gitea_version` before initiating binary download |
 | `gitea_gpg_key` | `7C9E68152594688862D62AF62D9AE806EC1592E2` | the gpg key the gitea binary is signed with |
 | `gitea_gpg_server` | `hkps://keys.openpgp.org` | A gpg key server where this role can download the gpg key |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Here is a deeper insight into the variables of this gitea role. For the exact fu
 | ------------- | ------------- | ----------- |
 | `gitea_version` | *(see [defaults/main.yml](defaults/main.yml#L3))* | The gitea version this role shoud install |
 | `gitea_version_check` | `true` | Check if installed version != `gitea_version` before initiating binary download |
-| `gitea_dl_url` | *(see [defaults/main.yml](defaults/main.yml#L5))* | The path from where this role downloads the gitea binary |
 | `gitea_gpg_key` | `7C9E68152594688862D62AF62D9AE806EC1592E2` | the gpg key the gitea binary is signed with |
 | `gitea_gpg_server` | `hkps://keys.openpgp.org` | A gpg key server where this role can download the gpg key |
 | `gitea_backup_on_upgrade` | `false` | Optionally a backup can be created with every update of gitea. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # gitea version
+# Use 'latest' to auto-update; upgrading past role version may lead to errors.
 gitea_version: '1.14.4'
 gitea_version_check: true
-gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version }}/gitea-{{ gitea_version }}-linux-{{ gitea_arch }}"
 gitea_gpg_key: '7C9E68152594688862D62AF62D9AE806EC1592E2'
 gitea_gpg_server: 'hkps://keys.openpgp.org'
 gitea_backup_on_upgrade: false

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -30,4 +30,4 @@
   when:
     - ansible_facts.services["gitea.service"] is defined
     - ansible_facts.services["gitea.service"].state == "running"
-    - gitea_active_version.stdout != gitea_version
+    - gitea_active_version.stdout != gitea_version_target

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -71,4 +71,4 @@
         owner: root
         group: root
       notify: "Restart gitea"
-  when: (not gitea_version_check|bool) or (not ansible_check_mode and (gitea_active_version.stdout != gitea_version))
+  when: (not gitea_version_check|bool) or (not ansible_check_mode and (gitea_active_version.stdout != gitea_version_target))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,14 +10,8 @@
 - name: Gather variables for each operating system
   ansible.builtin.include_vars: "{{ lookup('first_found', gitea_variables) }}"
 
-- name: "Check gitea version"
-  ansible.builtin.shell: "set -eo pipefail; /usr/local/bin/gitea -v | cut -d' ' -f 3"
-  args:
-    executable: /bin/bash
-  register: gitea_active_version
-  changed_when: false
-  failed_when: false
-  when: gitea_version_check|bool
+- name: Gather versioning information
+  ansible.builtin.include_tasks: set_version.yml
 
 - name: backup gitea before update
   ansible.builtin.include_tasks: backup.yml

--- a/tasks/set_version.yml
+++ b/tasks/set_version.yml
@@ -1,0 +1,34 @@
+---
+- name: "Check gitea installed version"
+  ansible.builtin.shell: "set -eo pipefail; /usr/local/bin/gitea -v | cut -d' ' -f 3"
+  args:
+    executable: /bin/bash
+  register: gitea_active_version
+  changed_when: false
+  failed_when: false
+
+- name: "Determine 'latest' version release"
+  block:
+    - name: "Get latest gitea release metadata"
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/go-gitea/gitea/releases/latest
+        return_content: true
+      register: gitea_remote_metadata
+ 
+    - name: "Set fact latest gitea release"
+      ansible.builtin.set_fact:
+        gitea_remote_version: "{{ gitea_remote_metadata.json.tag_name[1:] }}"
+ 
+    - name: "Set gitea version target (latest)"
+      ansible.builtin.set_fact:
+        gitea_version_target: "{{ gitea_remote_version }}"
+  when: gitea_version == "latest"
+
+- name: "Set gitea version target ({{ gitea_version }})"
+  ansible.builtin.set_fact:
+    gitea_version_target: "{{ gitea_version }}"
+  when: gitea_version != "latest"
+
+- name: "Generate gitea download URL"
+  ansible.builtin.set_fact:
+    gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version_target }}/gitea-{{ gitea_version_target }}-linux-{{ gitea_arch }}"

--- a/tasks/set_version.yml
+++ b/tasks/set_version.yml
@@ -14,11 +14,11 @@
         url: https://api.github.com/repos/go-gitea/gitea/releases/latest
         return_content: true
       register: gitea_remote_metadata
- 
+
     - name: "Set fact latest gitea release"
       ansible.builtin.set_fact:
         gitea_remote_version: "{{ gitea_remote_metadata.json.tag_name[1:] }}"
- 
+
     - name: "Set gitea version target (latest)"
       ansible.builtin.set_fact:
         gitea_version_target: "{{ gitea_remote_version }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -56,5 +56,5 @@ transfer_custom_footer:
     - 'files/gitea_footer/extra_links_footer.tmpl'
     - 'files/extra_links_footer.tmpl'
 
-playbook_version_number: 20  # should be int
+playbook_version_number: 21  # should be int
 playbook_version_path: 'do1jlr.gitea.version'


### PR DESCRIPTION
* Versioning logic moved into separate file; versioning is determined in that
  file and appropriate facts are set.
* Removed 'gitea_dl_url' from defaults/main.yml. This is now a generated fact
  from tasks/set_version.yml.
* Remote gitea version is only checked if 'latest' is set, otherwise no logic
  change.
* 'gitea_version' used in tasks is now 'gitea_version_target'. This is the
  target install version after versioning logic is applied. No change to end
  user usage of 'gitea_version' in defaults/main.yml.
* Updated documentation with usage and removal of 'gitea_dl_url'.

Included run logs for both 'latest' and '1.14.4' static version tests (successful).

Fixes #43
[gitea_latest.log](https://github.com/roles-ansible/ansible_role_gitea/files/6826973/gitea_latest.log)
[gitea_static.log](https://github.com/roles-ansible/ansible_role_gitea/files/6826974/gitea_static.log)
