### PR TITLE
v1.15.0 is available

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # gitea version
 # Use 'latest' to auto-update; upgrading past role version may lead to errors.
-gitea_version: '1.14.5'
+gitea_version: '1.15.0'
 gitea_version_check: true
 gitea_gpg_key: '7C9E68152594688862D62AF62D9AE806EC1592E2'
 gitea_gpg_server: 'hkps://keys.openpgp.org'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -56,5 +56,5 @@ transfer_custom_footer:
     - 'files/gitea_footer/extra_links_footer.tmpl'
     - 'files/extra_links_footer.tmpl'
 
-playbook_version_number: 24  # should be int
+playbook_version_number: 25  # should be int
 playbook_version_path: 'do1jlr.gitea.version'


### PR DESCRIPTION
https://github.com/go-gitea/gitea/releases/tag/v1.15.0 is available.

There a re some breaking-changes in gitea 1.15.0. Needs testing bevore merging this PR!