### PR TITLE
gitea secrets aren't necessarily strings

### DIFF
--- a/tasks/gitea_secrets.yml
+++ b/tasks/gitea_secrets.yml
@@ -4,35 +4,35 @@
   ansible.builtin.shell: 'umask 077; /usr/local/bin/gitea generate secret SECRET_KEY > /etc/gitea/gitea_secret_key'
   args:
     creates: '/etc/gitea/gitea_secret_key'
-  when: gitea_secret_key | length == 0
+  when: gitea_secret_key | string | length == 0
 
 - name: read gitea SECRET_KEY from file
   become: true
   ansible.builtin.slurp:
     src: '/etc/gitea/gitea_secret_key'
   register: remote_secret_key
-  when: gitea_secret_key | length == 0
+  when: gitea_secret_key | string | length == 0
 
 - name: set fact gitea_secret_key
   ansible.builtin.set_fact:
     gitea_secret_key: "{{ remote_secret_key['content'] | b64decode }}"
-  when: gitea_secret_key | length == 0
+  when: gitea_secret_key | string |  length == 0
 
 - name: generate gitea INTERNAL_TOKEN if not provided
   become: true
   ansible.builtin.shell: 'umask 077; /usr/local/bin/gitea generate secret INTERNAL_TOKEN > /etc/gitea/gitea_internal_token'
   args:
     creates: '/etc/gitea/gitea_internal_token'
-  when: gitea_internal_token | length == 0
+  when: gitea_internal_token | string | length == 0
 
 - name: read gitea INTERNAL_TOKEN from file
   become: true
   ansible.builtin.slurp:
     src: '/etc/gitea/gitea_internal_token'
   register: remote_internal_token
-  when: gitea_internal_token | length == 0
+  when: gitea_internal_token | string | length == 0
 
 - name: set fact gitea_internal_token
   ansible.builtin.set_fact:
     gitea_internal_token: "{{ remote_internal_token['content'] | b64decode }}"
-  when: gitea_internal_token | length == 0
+  when: gitea_internal_token | string | length == 0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -56,5 +56,5 @@ transfer_custom_footer:
     - 'files/gitea_footer/extra_links_footer.tmpl'
     - 'files/extra_links_footer.tmpl'
 
-playbook_version_number: 27  # should be int
+playbook_version_number: 28  # should be int
 playbook_version_path: 'do1jlr.gitea.version'


### PR DESCRIPTION
fixes errors like 	
```
fatal: [gitea]: FAILED! => {"msg": "The conditional check 'gitea_secret_key | length == 0' failed. The error was: Unexpected templating type error occurred on ({% if gitea_secret_key | length == 0 %} True {% else %} False {% endif %}): object of type 'AnsibleVaultEncryptedUnicode' has no len()
```
when using an encrypted string in vault for secrets
see https://github.com/ansible/ansible/issues/24425

This should be fixed in ansible 2.10, but centos8 is still shipping 2.9.25 