### PR TITLE
alternative fix for #74

### DIFF
--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -24,7 +24,7 @@
     - name: Backing up gitea before upgrade
       become: true
       ansible.builtin.command:
-        cmd: "sudo -u {{ gitea_user }} gitea dump -c /etc/gitea/gitea.ini"
+        cmd: "sudo -u {{ gitea_user }} env "PATH=$PATH" gitea dump -c /etc/gitea/gitea.ini"
         chdir: "{{ gitea_backup_location }}"
       changed_when: true
   when:


### PR DESCRIPTION
This is an alternative fix to the fix given in #75, it works around the problem instead of using become,
give full path to sudo, so it can find gitea
```
[jens@giteaqa ~]$ sudo -u gitea env "PATH=$PATH" which gitea
/usr/local/bin/gitea
[jens@giteaqa ~]$ sudo -u gitea  which gitea
which: no gitea in (/sbin:/bin:/usr/sbin:/usr/bin)
```