### PR TITLE
Fix newest ansible-lint issues

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,17 +4,20 @@ galaxy_info:
   author: do1jlr
   description: Ansible role to configure and deploy gitea, a painless self-hosted Git service.
   license: "BSD-3-Clause"
-  min_ansible_version: 2.11
-  github_branch: main
+  min_ansible_version: "2.11"
   platforms:
     - name: Debian
-      versions: all
+      versions:
+        - all
     - name: Ubuntu
-      versions: all
+      versions:
+        - all
     - name: Fedora
-      versions: all
+      versions:
+        - all
     - name: EL
-      versions: all
+      versions:
+        - all
   galaxy_tags:
     - gitea
     - git

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -2,7 +2,8 @@
 - name: Get service facts
   ansible.builtin.service_facts:
 
-- block:
+- name: Backup block
+  block:
     - name: Stopping gitea before upgrade
       become: true
       ansible.builtin.systemd:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,6 @@
 ---
-- block:
+- name: Dependency block
+  block:
     - name: Update apt cache
       become: true
       ansible.builtin.apt:
@@ -20,7 +21,8 @@
       retries: 5
       delay: 2
 
-- block:
+- name: Install block
+  block:
     - name: Download gitea archive
       ansible.builtin.get_url:
         url: "{{ gitea_dl_url }}.xz"


### PR DESCRIPTION
* schema: 'AIX' was expected (schema[meta])

This was unclear but specifying platform version "all" as a list entry, solved it

* schema: 2.11 is not of type 'string' (schema[meta])
* schema: Additional properties are not allowed ('github_branch' was unexpected) (schema[meta])
* unnamed-task: All tasks should be named