### PR TITLE
Change get_url/uri tasks to not use become

### DIFF
--- a/tasks/install_forgejo.yml
+++ b/tasks/install_forgejo.yml
@@ -31,6 +31,7 @@
         checksum: "sha256:{{ gitea_forgejo_checksum }}"
         mode: 0640
       register: _download_archive
+      become: false
       until: _download_archive is succeeded
       retries: 5
       delay: 2
@@ -41,6 +42,7 @@
         dest: "/tmp/{{ gitea_filename }}.asc"
         mode: 0640
       register: _download_asc
+      become: false
       until: _download_asc is succeeded
       retries: 5
       delay: 2

--- a/tasks/install_gitea.yml
+++ b/tasks/install_gitea.yml
@@ -31,6 +31,7 @@
         checksum: "sha256:{{ gitea_dl_url }}.xz.sha256"
         mode: 0640
       register: _download_archive
+      become: false
       until: _download_archive is succeeded
       retries: 5
       delay: 2
@@ -41,6 +42,7 @@
         dest: "/tmp/{{ gitea_filename }}.xz.asc"
         mode: 0640
       register: _download_asc
+      become: false
       until: _download_asc is succeeded
       retries: 5
       delay: 2

--- a/tasks/set_forgejo_version.yml
+++ b/tasks/set_forgejo_version.yml
@@ -15,6 +15,7 @@
         url: 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases?limit=1'
         return_content: true
       register: gitea_forgejo_remote_metadata
+      become: false
       when: not ansible_check_mode
 
     - name: "Fail if running in check mode without versions set."
@@ -44,6 +45,7 @@
     url: 'https://codeberg.org/api/v1/repos/forgejo/forgejo/releases/tags/v{{ gitea_version_target }}'
     return_content: true
   register: gitea_forgejo_remote_tags_metadata
+  become: false
   when: not ansible_check_mode
 
 - name: "Generate forgejo download url"
@@ -61,6 +63,7 @@
     url: "{{ gitea_forgejo_checksum_url | first }}"
     return_content: true
   register: _gitea_forgejo_dl_checksum
+  become: false
   when: not ansible_check_mode
 
 - name: Set forjeo checksum

--- a/tasks/set_gitea_version.yml
+++ b/tasks/set_gitea_version.yml
@@ -15,6 +15,7 @@
         url: https://api.github.com/repos/go-gitea/gitea/releases/latest
         return_content: true
       register: gitea_remote_metadata
+      become: false
       when: not ansible_check_mode
 
     - name: "Fail if running in check mode without versions set."


### PR DESCRIPTION
Hi there!

In the environment I work in we have to use an HTTP proxy in order to access the Internet. And even when running the playbooks with an ```environment``` set, the download tasks failed due to connection timeouts.

I noticed that, because of sudo, the ```http_proxy``` and ```https_proxy``` variables are not kept when become is used.

I changed all ```get_url``` and ```uri``` tasks to no longer use become.