### PR TITLE
feat: Add support for Gitea Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,13 +293,14 @@ Either you define exactly which release you install. Or you use the option ``lat
 | `gitea_lfs_storage_type` | `local` | Storage type for lfs |
 | `gitea_lfs_serve_direct` | `false` | Allows the storage driver to redirect to authenticated URLs to serve files directly. *(only Minio/S3)* |
 | `gitea_lfs_content_path` | `{{ gitea_home }}/data/lfs` | Where to store LFS files |
-| `gitea_lfs_extra` ||you can use this variable to pass additional config parameters in the `[lfs]` section of the config. |
+| `gitea_lfs_extra` | | you can use this variable to pass additional config parameters in the `[lfs]` section of the config. |
 
 ### Actions ([actions](https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions))
 | variable name | default value | description |
 | ------------- | ------------- | ----------- |
 | `gitea_actions_enabled` | `false` | Enable/Disable actions capabilities globaly. You may want to add `repo.actions` to `gitea_default_repo_units` to enable actions on all new repositories |
 | `gitea_actions_default_actions_url` | `https://gitea.com/` | Default address to get action plugins, e.g. the default value means downloading from `https://gitea.com/actions/checkout` for `uses: actions/checkout@v3` |
+| `gitea_actions_extra` | | you can use this variable to pass additional config parameters in the `[actions]` section of the config. |
 
 ### Other ([other](https://docs.gitea.io/en-us/config-cheat-sheet/#other-other))
 | variable name | default value | description |

--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ Either you define exactly which release you install. Or you use the option ``lat
 | `gitea_lfs_content_path` | `{{ gitea_home }}/data/lfs` | Where to store LFS files |
 | `gitea_lfs_extra` ||you can use this variable to pass additional config parameters in the `[lfs]` section of the config. |
 
+### Actions ([actions](https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions))
+| variable name | default value | description |
+| ------------- | ------------- | ----------- |
+| `gitea_actions_enabled` | `false` | Enable/Disable actions capabilities globaly. You may want to add `repo.actions` to `gitea_default_repo_units` to enable actions on all new repositories |
+| `gitea_actions_default_actions_url` | `https://gitea.com/` | Default address to get action plugins, e.g. the default value means downloading from `https://gitea.com/actions/checkout` for `uses: actions/checkout@v3` |
+
 ### Other ([other](https://docs.gitea.io/en-us/config-cheat-sheet/#other-other))
 | variable name | default value | description |
 | ------------- | ------------- | ----------- |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -231,6 +231,8 @@ gitea_lfs_extra: ''
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions
 gitea_actions_enabled: false
 gitea_actions_default_actions_url: "https://gitea.com"
+gitea_actions_extra: ''
+
 # Other (other)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#other-other
 gitea_other_show_footer_branding: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -227,6 +227,10 @@ gitea_lfs_serve_direct: false
 gitea_lfs_content_path: "{{ gitea_home }}/data/lfs"
 gitea_lfs_extra: ''
 
+# Actions (actions)
+# -> https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions
+gitea_actions_enabled: false
+gitea_actions_default_actions_url: "https://gitea.com"
 # Other (other)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#other-other
 gitea_other_show_footer_branding: false

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -271,6 +271,14 @@ PATH          = {{ gitea_lfs_content_path }}
 {% endif %}
 ;
 ;
+{% if gitea_actions_enabled | bool %}
+; -> https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions
+[actons]
+ENABLED  = {{ gitea_actions_enabled }}
+DEFAULT_ACTIONS_URL = {{ gitea_actions_default_actions_url }}
+{% endif %}
+;
+;
 ; Other (other)
 ; -> https://docs.gitea.io/en-us/config-cheat-sheet/#other-other
 [other]

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -276,6 +276,7 @@ PATH          = {{ gitea_lfs_content_path }}
 [actons]
 ENABLED  = {{ gitea_actions_enabled }}
 DEFAULT_ACTIONS_URL = {{ gitea_actions_default_actions_url }}
+{{ gitea_actions_extra }}
 {% endif %}
 ;
 ;

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -62,5 +62,5 @@ transfer_custom_footer:
     - 'files/gitea_footer/extra_links_footer.tmpl'
     - 'files/extra_links_footer.tmpl'
 
-playbook_version_number: 44  # should be int
+playbook_version_number: 45  # should be int
 playbook_version_path: 'do1jlr.gitea.version'


### PR DESCRIPTION
This PR allows to use [Gitea Actions](https://docs.gitea.io/en-us/usage/actions/overview/).

Gitea Actions is a new feature for running CI/CD pipelines. It is similar and compatible to [GitHub Actions](https://github.com/features/actions).
While the feature is still being developed, it has been usable since Gitea **v1.19**.
