### PR TITLE
chore(repo): Setup dependabot to watch for new releases of Github Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
[Dependabot](https://docs.github.com/en/code-security/dependabot) is a feature from Github that monitor vulnerabilities in dependencies; including Github actions.
It works by scanning repositories and creates PR for all outdated ones.
It is free for public repository.
