### PR TITLE
set --work-path

### DIFF
--- a/templates/gitea.service.j2
+++ b/templates/gitea.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ gitea_user }}
 Group={{ gitea_group }}
-ExecStart={{ gitea_full_executable_path }} web --config {{ gitea_configuration_path }}/gitea.ini --custom-path {{ gitea_custom }}/
+ExecStart={{ gitea_full_executable_path }} web --config {{ gitea_configuration_path }}/gitea.ini --custom-path {{ gitea_custom }}/ --work-path {{ gitea_home }}
 Restart=on-failure
 WorkingDirectory={{ gitea_home }}
 {% if gitea_systemd_cap_net_bind_service %}


### PR DESCRIPTION
for some reason this now needs to be set, otherwise my gitea binary just stops working, without an error message since latest gitea update.

relevant link https://github.com/go-gitea/gitea/pull/25417