### PR TITLE
Fix default user and org visibility

### DIFF
--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -183,8 +183,8 @@ DEFAULT_USER_IS_RESTRICTED = {{ gitea_default_user_is_restricted | ternary('true
 {% if gitea_email_domain_allowlist is defined and gitea_email_domain_allowlist | length  %}
 EMAIL_DOMAIN_ALLOWLIST = {{ gitea_email_domain_allowlist }}
 {% endif %}
-DEFAULT_USER_VISIBILITY = {{ gitea_default_user_visibility | ternary('true', 'false') }}
-DEFAULT_ORG_VISIBILITY = {{ gitea_default_org_visibility | ternary('true', 'false') }}
+DEFAULT_USER_VISIBILITY = {{ gitea_default_user_visibility }}
+DEFAULT_ORG_VISIBILITY = {{ gitea_default_org_visibility }}
 ALLOW_ONLY_INTERNAL_REGISTRATION = {{ gitea_allow_only_internal_registration | ternary('true', 'false') }}
 ALLOW_ONLY_EXTERNAL_REGISTRATION = {{ gitea_allow_only_external_registration | ternary('true', 'false') }}
 {{ gitea_service_extra_config }}


### PR DESCRIPTION
The new variables `DEFAULT_USER_VISIBILITY` and `DEFAULT_ORG_VISIBILITY` always were set to `true` because of a ternary filter.