### PR TITLE
Added check to stop execution when the remote version is higher

### DIFF
--- a/tasks/set_forgejo_version.yml
+++ b/tasks/set_forgejo_version.yml
@@ -97,6 +97,12 @@
     gitea_forgejo_signed_url: ['https://codeberg.org/attachments/ae5e50c6-e86e-4202-b95f-f142e8138e2f']
   when: ansible_check_mode
 
+- name: 'Assert that remote version is higher'
+  ansible.builtin.assert:
+    that:
+      - gitea_active_version is version(gitea_remote_version, 'lt')
+    fail_msg: ERROR: Remote version is lower then current version!
+
 - name: Show Download URLs  # noqa: H500
   ansible.builtin.debug:
     msg: "{{ item }}"

--- a/tasks/set_forgejo_version.yml
+++ b/tasks/set_forgejo_version.yml
@@ -101,7 +101,7 @@
   ansible.builtin.assert:
     that:
       - gitea_active_version is version(gitea_remote_version, 'lt')
-    fail_msg: ERROR: Remote version is lower then current version!
+    fail_msg: ERROR - Remote version is lower then current version!
 
 - name: Show Download URLs  # noqa: H500
   ansible.builtin.debug:

--- a/tasks/set_gitea_version.yml
+++ b/tasks/set_gitea_version.yml
@@ -40,6 +40,12 @@
     gitea_version_target: "{{ gitea_version }}"
   when: gitea_version != "latest"
 
+- name: 'Assert that remote version is higher'
+  ansible.builtin.assert:
+    that:
+      - gitea_active_version is version(gitea_remote_version, 'lt')
+    fail_msg: ERROR: Remote version is lower then current version!
+
 - name: "Generate gitea download URL"
   ansible.builtin.set_fact:
     gitea_dl_url: "https://github.com/go-gitea/gitea/releases/download/v{{ gitea_version_target }}/gitea-{{ gitea_version_target }}-linux-{{ gitea_arch }}"

--- a/tasks/set_gitea_version.yml
+++ b/tasks/set_gitea_version.yml
@@ -44,7 +44,7 @@
   ansible.builtin.assert:
     that:
       - gitea_active_version is version(gitea_remote_version, 'lt')
-    fail_msg: ERROR: Remote version is lower then current version!
+    fail_msg: ERROR - Remote version is lower then current version!
 
 - name: "Generate gitea download URL"
   ansible.builtin.set_fact:


### PR DESCRIPTION
This is a quick fix for #138 for both Gitea and Forgejo.

IMHO it's not the definitive solution to this problem, but at least this will prevent existing deployments from unexpectedly breaking :-)