### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Either you define exactly which release you install. Or you use the option ``lat
 | `gitea_auto_watch_new_repos` | `true` | Enable this to let all organisation users watch new repos when they are created (true/false) |
 | `gitea_autowatch_on_change` | `true` | Enable this to make users watch a repository after their first commit to it (true/false) |
 | `gitea_register_manual_confirm` | `false` | Enable this to manually confirm new registrations. Requires REGISTER_EMAIL_CONFIRM to be disabled. |
-| `gitea_default_allow_create_organization` | `true` | Allow new users to create organizations by default (true/false) |
+| `gitea_default_allow_create_organization` | `false` | Allow new users to create organizations by default (true/false) |
 | `gitea_email_domain_allowlist` | | If non-empty, comma separated list of domain names that can only be used to register on this instance, wildcard is supported. |
 | `gitea_default_user_visibility` | `public` | Set default visibility mode for users, either "public", "limited" or "private". |
 | `gitea_default_org_visibility` | `public` | Set default visibility mode for organisations, either "public", "limited" or "private". |


### PR DESCRIPTION
According to `defaults/main.yml`, the default value for `gitea_default_allow_create_organization` variable is `false`. However in the current README, the default value is `true`. This commit will fix the disrepancy.