### PR TITLE
Fix creation of users

### DIFF
--- a/tasks/local_git_users.yml
+++ b/tasks/local_git_users.yml
@@ -15,8 +15,8 @@
     --must-change-password={{ item.must_change_password }} --admin={{ item.admin }}'
   register: _gitearesult
   failed_when:
-    - '"successfully created" not in gitearesult.stdout'
+    - '"successfully created" not in _gitearesult.stdout'
   changed_when:
-    - '"successfully created!" in gitearesult.stdout'
+    - '"successfully created!" in _gitearesult.stdout'
   when: "_giteausers is defined and item.name not in _giteausers"
   loop: "{{ gitea_users }}"

--- a/tasks/local_git_users.yml
+++ b/tasks/local_git_users.yml
@@ -8,10 +8,10 @@
 - name: Use gitea cli to create user
   become: true
   ansible.builtin.command: |
-    su - {{ gitea_user }} -c
-    '{{ gitea_full_executable_path }} -c {{ gitea_configuration_path }}/gitea.ini
-    admin user create --username "{{ item.name }}"
-    --password "{{ item.password }}" --email "{{ item.email }}"
+    su - {{ gitea_user }} -c \
+    '{{ gitea_full_executable_path }} -c {{ gitea_configuration_path }}/gitea.ini \
+    admin user create --username "{{ item.name }}" \
+    --password "{{ item.password }}" --email "{{ item.email }}" \
     --must-change-password={{ item.must_change_password }} --admin={{ item.admin }}'
   register: _gitearesult
   failed_when:

--- a/tasks/local_git_users.yml
+++ b/tasks/local_git_users.yml
@@ -18,5 +18,5 @@
     - '"successfully created" not in _gitearesult.stdout'
   changed_when:
     - '"successfully created!" in _gitearesult.stdout'
-  when: "_giteausers is defined and item.name not in _giteausers"
+  when: "_giteausers is defined and item.name not in _giteausers.stdout"
   loop: "{{ gitea_users }}"

--- a/tasks/local_git_users.yml
+++ b/tasks/local_git_users.yml
@@ -2,7 +2,7 @@
 - name: Identify gitea users
   ansible.builtin.command: su - {{ gitea_user }} -c '{{ gitea_full_executable_path }} -c {{ gitea_configuration_path }}/gitea.ini admin user list'
   become: true
-  register: _giteusers
+  register: _giteausers
   changed_when: false
 
 - name: Use gitea cli to create user
@@ -18,5 +18,5 @@
     - '"successfully created" not in gitearesult.stdout'
   changed_when:
     - '"successfully created!" in gitearesult.stdout'
-  when: "_giteusers is defined and item.name in _giteusers"
+  when: "_giteausers is defined and item.name not in _giteausers"
   loop: "{{ gitea_users }}"


### PR DESCRIPTION
When using version 19e39f9 to set up a new Gitea instance, the desired users aren't created. This is due to the when condition skipping the creation.