### PR TITLE
fix: use correct key for oauth2 section ENABLED

### DIFF
--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -257,7 +257,7 @@ TOKEN = {{ gitea_metrics_token }}
 ;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#oauth2-oauth2
 [oauth2]
-ENABLE = {{ gitea_oauth2_enabled | ternary('true', 'false') }}
+ENABLED = {{ gitea_oauth2_enabled | ternary('true', 'false') }}
 JWT_SECRET = {{ gitea_oauth2_jwt_secret }}
 {{ gitea_oauth2_extra_config }}
 ;


### PR DESCRIPTION
Hi 
This PR resolve this new error message from Gitea latest relase (v1.22.0) : 

Deprecation: config option [oauth2].ENABLE presents, please use [oauth2].ENABLED instead because this fallback will be/has been removed in v1.23.0