### PR TITLE
Fix for Issue #165 missing themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ This is because the Forgejo project maintains both `stable` and `old stable` rel
 | variable name | default value | description |
 | ------------- | ------------- | ----------- |
 | `gitea_show_user_email` | `false` | Do you want to display email addresses ? (true/false) |
-| `gitea_theme_default` | `auto` | Default theme |
-| `gitea_themes` | `auto,gitea,arc-green` | List of enabled themes |
+| `gitea_theme_default` | `gitea-auto` or `forgejo-auto` | Default theme |
+| `gitea_themes` | `gitea-auto,gitea-light,gitea-dark` or `forgejo-auto,forgejo-light,forgejo-dark` (plus accessible variants see `defaults/forgejo.yml` for full list)| List of enabled themes |
 | `gitea_ui_extra_config` | | you can use this variable to pass additional config parameters in the `[ui]` section of the config. |
 
 ### UI - Meta ([ui.meta](https://docs.gitea.com/administration/config-cheat-sheet#ui---metadata-uimeta))

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This is because the Forgejo project maintains both `stable` and `old stable` rel
 | ------------- | ------------- | ----------- |
 | `gitea_show_user_email` | `false` | Do you want to display email addresses ? (true/false) |
 | `gitea_theme_default` | `gitea-auto` or `forgejo-auto` | Default theme |
-| `gitea_themes` | `gitea-auto,gitea-light,gitea-dark` or `forgejo-auto,forgejo-light,forgejo-dark` (plus accessible variants see `defaults/forgejo.yml` for full list)| List of enabled themes |
+| `gitea_themes` | (See `defaults/gitea.yml` or `defaults/forgejo.yml`)| List of enabled themes |
 | `gitea_ui_extra_config` | | you can use this variable to pass additional config parameters in the `[ui]` section of the config. |
 
 ### UI - Meta ([ui.meta](https://docs.gitea.com/administration/config-cheat-sheet#ui---metadata-uimeta))

--- a/defaults/forgejo.yml
+++ b/defaults/forgejo.yml
@@ -1,0 +1,3 @@
+---
+gitea_theme_default: "forgejo-auto"
+gitea_themes: "forgejo-auto, forgejo-light, forgejo-dark,gitea-auto,gitea-light,gitea-dark,forgejo-auto-deuteranopia-protanopia,forgejo-light-deuteranopia-protanopia,forgejo-dark-deuteranopia-protanopia,forgejo-auto-tritanopia,forgejo-light-tritanopia,forgejo-dark-tritanopia"

--- a/defaults/forgejo.yml
+++ b/defaults/forgejo.yml
@@ -1,3 +1,5 @@
 ---
 gitea_theme_default: "forgejo-auto"
-gitea_themes: "forgejo-auto, forgejo-light, forgejo-dark,gitea-auto,gitea-light,gitea-dark,forgejo-auto-deuteranopia-protanopia,forgejo-light-deuteranopia-protanopia,forgejo-dark-deuteranopia-protanopia,forgejo-auto-tritanopia,forgejo-light-tritanopia,forgejo-dark-tritanopia"
+# yamllint disable rule:line-length
+gitea_themes: "forgejo-auto,forgejo-light,forgejo-dark,gitea-auto,gitea-light,gitea-dark,forgejo-auto-deuteranopia-protanopia,forgejo-light-deuteranopia-protanopia,forgejo-dark-deuteranopia-protanopia,forgejo-auto-tritanopia,forgejo-light-tritanopia,forgejo-dark-tritanopia"
+# yamllint enable rule:line-length

--- a/defaults/gitea.yml
+++ b/defaults/gitea.yml
@@ -1,0 +1,3 @@
+---
+gitea_theme_default: "gitea-auto"
+gitea_themes: "gitea-auto,gitea-light,gitea-dark"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -92,8 +92,6 @@ gitea_cors_extra: ''
 # UI (ui)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#ui-ui
 gitea_show_user_email: false
-gitea_theme_default: 'auto'
-gitea_themes: 'auto,gitea,arc-green'
 gitea_ui_extra_config: ''
 
 # UI - Metadata (ui.meta)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,15 @@
       ansible.builtin.fail:
         msg: "Currently only {{ gitea_supported_forks }} are supported."
 
+- name: Gather Gitea/Forgejo UI Theme variables
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ gitea_fork }}.yml"
+      paths:
+        - "defaults"
+
 - name: Gather variables for each operating system
   ansible.builtin.include_vars:
     file: "{{ lookup('first_found', gitea_variables) }}"


### PR DESCRIPTION
This does the following:

- Updates the list of themes for gitea and forgejo to match upstream
- Moves the theme vars into per fork files
- Loads the theme vars based on the value of the gitea_fork var
- Updates the README section on default UI vars to match these changes

It's been tested:
- running Ansible on a manjaro Linux host against a Debian 12 VM, with Forgejo as the specified fork.
- Leaving the vars as default resulted in the correct `forgejo-auto` theme being used and fixed my original issue #165 
- A second run overriding `gitea_theme_default` to `forgejo-dark` in my local host_vars worked as expected.
- The full list of themes was available in the Forgejo web UI user settings and worked when selected.

I have not yet tested Gitea and will likely not have time for several weeks.