### PR TITLE
expose `gitea_session_provider_config`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -204,6 +204,7 @@ gitea_mailer_extra_config: ''
 # Session (session)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#session-session
 gitea_session_provider: 'file'
+gitea_session_provider_config: "{{ gitea_home }}/data/sessions"
 gitea_session_extra_config: ''
 
 # Picture (picture)

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -216,7 +216,7 @@ SEND_AS_PLAIN_TEXT = {{ gitea_mailer_send_as_plaintext | ternary('true', 'false'
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#session-session
 [session]
 PROVIDER = {{ gitea_session_provider }}
-PROVIDER_CONFIG = {{ gitea_home }}/data/sessions
+PROVIDER_CONFIG = {{ gitea_session_provider_config }}
 {{ gitea_session_extra_config }}
 ;
 ;


### PR DESCRIPTION
Currently hardcoded, so one cannot use other providers than `file`. 