### PR TITLE
chore: improve role idempotency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # Choose between https://forgejo.org/ and https://gitea.io/
-gitea_fork: "gitea" # 'gitea' and 'forgejo' are valid options
+# 'gitea' and 'forgejo' are valid options
+gitea_fork: "gitea"
 
 # gitea version
 # Use 'latest' to auto-update; upgrading past role version may lead to errors.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,28 +1,28 @@
 ---
 # Choose between https://forgejo.org/ and https://gitea.io/
-gitea_fork: 'gitea'  # 'gitea' and 'forgejo' are valid options
+gitea_fork: "gitea" # 'gitea' and 'forgejo' are valid options
 
 # gitea version
 # Use 'latest' to auto-update; upgrading past role version may lead to errors.
-gitea_version: 'latest'
+gitea_version: "latest"
 gitea_version_check: true
-gitea_gpg_key: '7C9E68152594688862D62AF62D9AE806EC1592E2'
-gitea_forgejo_gpg_key: 'EB114F5E6C0DC2BCDD183550A4B61A2DC5923710'
-gitea_gpg_server: 'hkps://keys.openpgp.org'
-gitea_gpg_keyserver_option: ''
+gitea_gpg_key: "7C9E68152594688862D62AF62D9AE806EC1592E2"
+gitea_forgejo_gpg_key: "EB114F5E6C0DC2BCDD183550A4B61A2DC5923710"
+gitea_gpg_server: "hkps://keys.openpgp.org"
+gitea_gpg_keyserver_option: ""
 gitea_backup_on_upgrade: false
 gitea_backup_location: "{{ gitea_home }}/backups/"
 submodules_versioncheck: false
 
 # gitea in the linux world
-gitea_group: 'gitea'
+gitea_group: "gitea"
 # gitea_groups: []  # Optional a list of groups user gitea will be added to
-gitea_home: '/var/lib/gitea'
-gitea_user_home: '{{ gitea_home }}'
-gitea_executable_path: '/usr/local/bin/gitea'
-gitea_forgejo_executable_path: '/usr/local/bin/forgejo'
-gitea_configuration_path: '/etc/gitea'
-gitea_shell: '/bin/false'
+gitea_home: "/var/lib/gitea"
+gitea_user_home: "{{ gitea_home }}"
+gitea_executable_path: "/usr/local/bin/gitea"
+gitea_forgejo_executable_path: "/usr/local/bin/forgejo"
+gitea_configuration_path: "/etc/gitea"
+gitea_shell: "/bin/false"
 gitea_systemd_cap_net_bind_service: false
 
 # optional users on gitea instance
@@ -37,128 +37,128 @@ gitea_users: []
 
 # Overall (DEFAULT)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#overall-default
-gitea_app_name: 'Gitea'
-gitea_user: 'gitea'
-gitea_run_mode: 'prod'
-gitea_fqdn: 'localhost'
+gitea_app_name: "Gitea"
+gitea_user: "gitea"
+gitea_run_mode: "prod"
+gitea_fqdn: "localhost"
 
 # Repository (repository)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#repository-repository
-gitea_default_branch: 'main'
-gitea_default_private: 'last'
-gitea_default_repo_units: 'repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki,repo.projects'
-gitea_disabled_repo_units: ''
+gitea_default_branch: "main"
+gitea_default_private: "last"
+gitea_default_repo_units: "repo.code,repo.releases,repo.issues,repo.pulls,repo.wiki,repo.projects"
+gitea_disabled_repo_units: ""
 gitea_disable_http_git: false
 gitea_disable_stars: false
 gitea_enable_push_create_org: false
 gitea_enable_push_create_user: false
 gitea_force_private: false
-gitea_user_repo_limit: '-1'
+gitea_user_repo_limit: "-1"
 gitea_repository_root: "{{ gitea_home }}/repos"
-gitea_repository_extra_config: ''
+gitea_repository_extra_config: ""
 
 # Repository - Upload (repository.upload)
 # -> https://docs.gitea.io/en-us/administration/config-cheat-sheet/#repository---upload-repositoryupload
 gitea_repository_upload_enabled: true
 gitea_repository_upload_max_size: 4
-gitea_repository_upload_extra_config: ''
+gitea_repository_upload_extra_config: ""
 
 # Repository - Signing (repository.signing)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#repository---signing-repositorysigning
 gitea_enable_repo_signing_options: false
-gitea_repo_signing_key: 'default'
-gitea_repo_signing_name: ''
-gitea_repo_signing_email: ''
-gitea_repo_initial_commit: 'always'
-gitea_repo_default_trust_model: 'collaborator'
-gitea_repo_wiki: 'never'
-gitea_repo_crud_actions: 'pubkey, twofa, parentsigned'
-gitea_repo_merges: ' pubkey, twofa, basesigned, commitssigned'
-gitea_enable_repo_signing_extra: ''
+gitea_repo_signing_key: "default"
+gitea_repo_signing_name: ""
+gitea_repo_signing_email: ""
+gitea_repo_initial_commit: "always"
+gitea_repo_default_trust_model: "collaborator"
+gitea_repo_wiki: "never"
+gitea_repo_crud_actions: "pubkey, twofa, parentsigned"
+gitea_repo_merges: " pubkey, twofa, basesigned, commitssigned"
+gitea_enable_repo_signing_extra: ""
 
 # CORS (cors)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#cors-cors
 gitea_enable_cors: false
-gitea_cors_scheme: 'http'
-gitea_cors_allow_domain: '*'
+gitea_cors_scheme: "http"
+gitea_cors_allow_domain: "*"
 gitea_cors_allow_subdomain: false
-gitea_cors_methods: 'GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS'
-gitea_cors_max_age: '10m'
+gitea_cors_methods: "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS"
+gitea_cors_max_age: "10m"
 gitea_cors_allow_credentials: false
-gitea_cors_headers: 'Content-Type,User-Agent'
-gitea_cors_x_frame_options: 'SAMEORIGIN'
-gitea_cors_extra: ''
+gitea_cors_headers: "Content-Type,User-Agent"
+gitea_cors_x_frame_options: "SAMEORIGIN"
+gitea_cors_extra: ""
 
 # UI (ui)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#ui-ui
 gitea_show_user_email: false
-gitea_ui_extra_config: ''
+gitea_ui_extra_config: ""
 
 # UI - Metadata (ui.meta)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#ui---metadata-uimeta
-gitea_ui_author: 'Gitea - Git with a cup of tea'
-gitea_ui_description: 'Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go:'
-gitea_ui_keywords: 'go,git,self-hosted,gitea,forgejo'
-gitea_ui_meta_extra_config: ''
+gitea_ui_author: "Gitea - Git with a cup of tea"
+gitea_ui_description: "Gitea (Git with a cup of tea) is a painless self-hosted Git service written in Go:"
+gitea_ui_keywords: "go,git,self-hosted,gitea,forgejo"
+gitea_ui_meta_extra_config: ""
 
 # Server (server)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#server-server
-gitea_protocol: 'http'
+gitea_protocol: "http"
 gitea_http_domain: "{{ gitea_fqdn }}"
 gitea_root_url: "http://{{ gitea_fqdn }}:3000"
-gitea_http_listen: '127.0.0.1'
-gitea_http_port: '3000'
+gitea_http_listen: "127.0.0.1"
+gitea_http_port: "3000"
 gitea_start_ssh: true
 gitea_ssh_domain: "{{ gitea_fqdn }}"
-gitea_ssh_port: '2222'
-gitea_ssh_listen: '0.0.0.0'
+gitea_ssh_port: "2222"
+gitea_ssh_listen: "0.0.0.0"
 gitea_offline_mode: true
-gitea_landing_page: 'home'
+gitea_landing_page: "home"
 gitea_lfs_server_enabled: false
-gitea_lfs_jwt_secret: ''
+gitea_lfs_jwt_secret: ""
 gitea_redirect_other_port: false
-gitea_port_to_redirect: '80'
+gitea_port_to_redirect: "80"
 gitea_enable_tls_certs: false
-gitea_tls_cert_file: 'https/cert.pem'
-gitea_tls_key_file: 'https/key.pem'
+gitea_tls_cert_file: "https/cert.pem"
+gitea_tls_key_file: "https/key.pem"
 gitea_enable_acme: false
-gitea_acme_url: ''
+gitea_acme_url: ""
 gitea_acme_accepttos: false
-gitea_acme_directory: 'https'
-gitea_acme_email: ''
-gitea_acme_ca_root: ''
-gitea_server_extra_config: ''
+gitea_acme_directory: "https"
+gitea_acme_email: ""
+gitea_acme_ca_root: ""
+gitea_server_extra_config: ""
 
 # Database (database)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#database-database
-gitea_db_type: 'sqlite3'
-gitea_db_host: '127.0.0.0:3306'
-gitea_db_name: 'root'
-gitea_db_user: 'gitea'
-gitea_db_password: 'lel'
-gitea_db_ssl: 'disable'
+gitea_db_type: "sqlite3"
+gitea_db_host: "127.0.0.0:3306"
+gitea_db_name: "root"
+gitea_db_user: "gitea"
+gitea_db_password: "lel"
+gitea_db_ssl: "disable"
 gitea_db_path: "{{ gitea_home }}/data/gitea.db"
 gitea_db_log_sql: false
-gitea_database_extra_config: ''
+gitea_database_extra_config: ""
 
 # Indexer (indexer)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#indexer-indexer
 gitea_repo_indexer_enabled: false
-gitea_repo_indexer_include: ''
-gitea_repo_indexer_exclude: ''
+gitea_repo_indexer_include: ""
+gitea_repo_indexer_exclude: ""
 gitea_repo_exclude_vendored: true
-gitea_repo_indexer_max_file_size: '1048576'
-gitea_indexer_extra_config: ''
-gitea_queue_issue_indexer_extra_config: ''
+gitea_repo_indexer_max_file_size: "1048576"
+gitea_indexer_extra_config: ""
+gitea_queue_issue_indexer_extra_config: ""
 
 # Security (security)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#security-security
-gitea_secret_key: ''
+gitea_secret_key: ""
 gitea_disable_git_hooks: true
 gitea_disable_webhooks: false
-gitea_internal_token: ''
+gitea_internal_token: ""
 gitea_password_check_pwn: false
-gitea_security_extra_config: ''
+gitea_security_extra_config: ""
 
 # Service (service)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#service-service
@@ -181,84 +181,84 @@ gitea_default_org_visibility: public
 gitea_allow_only_internal_registration: false
 gitea_allow_only_external_registration: false
 gitea_show_milestones_dashboard_page: true
-gitea_service_extra_config: ''
+gitea_service_extra_config: ""
 
 # Mailer [mailer]
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#mailer-mailer
 gitea_mailer_enabled: false
-gitea_mailer_protocol: 'dummy'
-gitea_mailer_smtp_addr: ''
-gitea_mailer_smtp_port: ''
+gitea_mailer_protocol: "dummy"
+gitea_mailer_smtp_addr: ""
+gitea_mailer_smtp_port: ""
 gitea_mailer_use_client_cert: false
-gitea_mailer_client_cert_file: ''
-gitea_mailer_client_key_file: ''
+gitea_mailer_client_cert_file: ""
+gitea_mailer_client_key_file: ""
 gitea_mailer_force_trust_server_cert: false
-gitea_mailer_user: ''
-gitea_mailer_password: ''
+gitea_mailer_user: ""
+gitea_mailer_password: ""
 gitea_mailer_enable_helo: true
 gitea_mailer_from: "noreply@{{ gitea_http_domain }}"
-gitea_subject_prefix: ''
+gitea_subject_prefix: ""
 gitea_mailer_send_as_plaintext: false
-gitea_mailer_extra_config: ''
+gitea_mailer_extra_config: ""
 
 # Session (session)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#session-session
-gitea_session_provider: 'file'
+gitea_session_provider: "file"
 gitea_session_provider_config: "{{ gitea_home }}/data/sessions"
-gitea_session_extra_config: ''
+gitea_session_extra_config: ""
 
 # Picture (picture)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#picture-picture
-gitea_picture_extra_config: ''
+gitea_picture_extra_config: ""
 
 # Issue and pull request attachments (attachment)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#issue-and-pull-request-attachments-attachment
 gitea_attachment_enabled: true
-gitea_attachment_types: '.csv,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.xls,.xlsx,.zip'
+gitea_attachment_types: ".csv,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.xls,.xlsx,.zip"
 gitea_attachment_max_size: 4
-gitea_attachment_extra_config: ''
+gitea_attachment_extra_config: ""
 
 # Log (log)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#log-log
 gitea_log_systemd: false
-gitea_log_level: 'Warn'
-gitea_log_extra_config: ''
+gitea_log_level: "Warn"
+gitea_log_extra_config: ""
 
 # Metrics (metrics)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#metrics-metrics
 gitea_metrics_enabled: false
-gitea_metrics_token: ''
-gitea_metrics_extra: ''
+gitea_metrics_token: ""
+gitea_metrics_extra: ""
 
 # OAuth2 (oauth2)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#oauth2-oauth2
 gitea_oauth2_enabled: true
-gitea_oauth2_jwt_secret: ''
-gitea_oauth2_extra_config: ''
+gitea_oauth2_jwt_secret: ""
+gitea_oauth2_extra_config: ""
 
 # Federation (federation)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#federation-federation
 gitea_federation_enabled: false
 gitea_federation_share_user_stats: false
-gitea_federation_extra: ''
+gitea_federation_extra: ""
 
 # Packages (packages)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#packages-packages
 gitea_packages_enabled: true
-gitea_packages_extra: ''
+gitea_packages_extra: ""
 
 # LFS (lfs)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#lfs-lfs
-gitea_lfs_storage_type: 'local'
+gitea_lfs_storage_type: "local"
 gitea_lfs_serve_direct: false
 gitea_lfs_content_path: "{{ gitea_home }}/data/lfs"
-gitea_lfs_extra: ''
+gitea_lfs_extra: ""
 
 # Actions (actions)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#actions-actions
 gitea_actions_enabled: false
 gitea_actions_default_actions_url: github
-gitea_actions_extra: ''
+gitea_actions_extra: ""
 
 # Other (other)
 # -> https://docs.gitea.io/en-us/config-cheat-sheet/#other-other
@@ -272,10 +272,10 @@ gitea_extra_config: ""
 
 # fail2ban
 gitea_fail2ban_enabled: false
-gitea_fail2ban_jail_maxretry: '10'
-gitea_fail2ban_jail_findtime: '3600'
-gitea_fail2ban_jail_bantime: '900'
-gitea_fail2ban_jail_action: 'iptables-allports'
+gitea_fail2ban_jail_maxretry: "10"
+gitea_fail2ban_jail_findtime: "3600"
+gitea_fail2ban_jail_bantime: "900"
+gitea_fail2ban_jail_action: "iptables-allports"
 
 # gitea customisation
 gitea_custom_search: "files/host_files/{{ inventory_hostname }}/gitea"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,11 +10,11 @@
 - name: "Configure gitea"
   become: true
   ansible.builtin.template:
-    src: 'templates/gitea.ini.j2'
+    src: "templates/gitea.ini.j2"
     dest: "{{ gitea_configuration_path }}/gitea.ini"
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: '0640'
+    mode: "0640"
   notify: "systemctl restart gitea"
 
 - name: "Service gitea"

--- a/tasks/customize_footer.yml
+++ b/tasks/customize_footer.yml
@@ -6,7 +6,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: 'u=rwX,g=rX,o='
+    mode: "0755"
   loop:
     - "{{ gitea_custom }}/templates"
     - "{{ gitea_custom }}/templates/custom"
@@ -18,7 +18,7 @@
     dest: "{{ gitea_custom }}/templates/custom/extra_links_footer.tmpl"
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: '0640'
+    mode: "0755"
   failed_when: false
   tags: skip_ansible_lint
   notify: "systemctl restart gitea"

--- a/tasks/customize_logo.yml
+++ b/tasks/customize_logo.yml
@@ -6,7 +6,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX,o="
+    mode: "0755"
   loop:
     - "{{ gitea_custom }}/public"
     - "{{ gitea_custom }}/public/assets"

--- a/tasks/customize_public_files.yml
+++ b/tasks/customize_public_files.yml
@@ -6,7 +6,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX,o="
+    mode: "0755"
   loop:
     - "{{ gitea_custom }}/public/assets/"
 
@@ -18,7 +18,7 @@
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
     directory_mode: true
-    mode: "u=rwX,g=rX,o="
+    mode: "0755"
   failed_when: false
   tags: skip_ansible_lint
   notify: "systemctl restart gitea"
@@ -30,7 +30,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX,o="
+    mode: "0755"
 
 - name: Get custom themes
   when: gitea_custom_themes is defined
@@ -39,6 +39,6 @@
     dest: "{{ gitea_custom }}/css/{{ item.name | basename }}"
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX,o="
+    mode: "0755"
   loop: "{{ gitea_custom_themes }}"
   notify: "systemctl restart gitea"

--- a/tasks/directory.yml
+++ b/tasks/directory.yml
@@ -6,8 +6,7 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX"
-    recurse: true
+    mode: "0755"
   loop:
     - "{{ gitea_user_home }}"
     - "{{ gitea_home }}"
@@ -26,7 +25,6 @@
     state: directory
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
-    mode: "u=rwX,g=rX,o="
-    recurse: true
+    mode: "0755"
   loop:
     - "{{ gitea_configuration_path }}"

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -116,8 +116,6 @@ LOG_SQL = {{ gitea_db_log_sql | ternary('true', 'false') }}
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#indexer-indexer
 [indexer]
 ISSUE_INDEXER_PATH = {{ gitea_home }}/indexers/issues.bleve
-ISSUE_INDEXER_TYPE = {{ gitea_issue_indexer_type }}
-ISSUE_INDEXER_CONN_STR = {{ gitea_issue_indexer_conn_str }}
 REPO_INDEXER_ENABLED = {{ gitea_repo_indexer_enabled | ternary('true', 'false') }}
 REPO_INDEXER_PATH = {{ gitea_home }}/indexers/repos.bleve
 REPO_INDEXER_INCLUDE = {{ gitea_repo_indexer_include }}

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -1,17 +1,14 @@
 ; this file is the configuration of your local Gitea instance
-{{ ansible_managed | comment(decoration="; ") }}
-;
+; {{ ansible_managed }}
 ; This file overwrites the default values from Gitea.
 ; undefined variables will use the default value from Gitea.
 ; Cheat Sheet: https://docs.gitea.com/next/administration/config-cheat-sheet/
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet#overall-default
 APP_NAME = {{ gitea_app_name }}
 RUN_USER = {{ gitea_user }}
 RUN_MODE = {{ gitea_run_mode }}
 WORK_PATH = {{ gitea_home }}
-;
-;
+
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#repository-repository
 [repository]
 ROOT = {{ gitea_repository_root }}
@@ -26,16 +23,12 @@ DEFAULT_REPO_UNITS = {{ gitea_default_repo_units }}
 DISABLE_STARS = {{ gitea_disable_stars | ternary('true', 'false') }}
 DEFAULT_BRANCH = {{ gitea_default_branch }}
 {{ gitea_repository_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/administration/config-cheat-sheet/#repository---upload-repositoryupload
 [repository.upload]
 ENABLED = {{ gitea_repository_upload_enabled | ternary('true', 'false') }}
 TEMP_PATH = {{ gitea_home }}/data/tmp/uploads
 FILE_MAX_SIZE = {{ gitea_repository_upload_max_size }}
 {{ gitea_repository_upload_extra_config }}
-;
-;
 {% if gitea_enable_repo_signing_options | bool %}
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#repository---signing-repositorysigning
 [repository.signing]
@@ -48,11 +41,8 @@ WIKI = {{ gitea_repo_wiki }}
 CRUD_ACTIONS = {{ gitea_repo_crud_actions }}
 MERGES = {{ gitea_repo_merges }}
 {{ gitea_enable_repo_signing_extra }}
-;
 {% endif %}
-;
 {% if gitea_enable_cors | bool %}
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#cors-cors
 [cors]
 ENABLED = {{ gitea_enable_cors | ternary('true', 'false') }}
@@ -65,25 +55,18 @@ ALLOW_CREDENTIALS = {{ gitea_cors_allow_credentials | ternary('true', 'false') }
 HEADERS = {{ gitea_cors_headers }}
 X_FRAME_OPTIONS = {{ gitea_cors_x_frame_options }}
 {{ gitea_cors_extra }}
-;
 {% endif %}
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#ui-ui
 [ui]
 THEMES = {{ gitea_themes }}
 DEFAULT_THEME = {{ gitea_theme_default }}
 SHOW_USER_EMAIL = {{ gitea_show_user_email | ternary('true', 'false') }}
 {{ gitea_ui_extra_config }}
-;
-;
-;
 [ui.meta]
 AUTHOR = {{ gitea_ui_author }}
 DESCRIPTION = {{ gitea_ui_description }}
 KEYWORDS = {{ gitea_ui_keywords }}
 {{ gitea_ui_meta_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#server-server
 [server]
 APP_DATA_PATH = {{ gitea_home }}/data
@@ -119,8 +102,6 @@ ACME_EMAIL = {{ gitea_acme_email }}
 ACME_CA_ROOT = {{ gitea_acme_ca_root }}
 {% endif %}
 {{ gitea_server_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#database-database
 [database]
 DB_TYPE = {{ gitea_db_type }}
@@ -132,11 +113,11 @@ SSL_MODE = {{ gitea_db_ssl }}
 PATH = {{ gitea_db_path }}
 LOG_SQL = {{ gitea_db_log_sql | ternary('true', 'false') }}
 {{ gitea_database_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#indexer-indexer
 [indexer]
 ISSUE_INDEXER_PATH = {{ gitea_home }}/indexers/issues.bleve
+ISSUE_INDEXER_TYPE = {{ gitea_issue_indexer_type }}
+ISSUE_INDEXER_CONN_STR = {{ gitea_issue_indexer_conn_str }}
 REPO_INDEXER_ENABLED = {{ gitea_repo_indexer_enabled | ternary('true', 'false') }}
 REPO_INDEXER_PATH = {{ gitea_home }}/indexers/repos.bleve
 REPO_INDEXER_INCLUDE = {{ gitea_repo_indexer_include }}
@@ -144,15 +125,11 @@ REPO_INDEXER_EXCLUDE = {{ gitea_repo_indexer_exclude }}
 REPO_INDEXER_EXCLUDE_VENDORED = {{ gitea_repo_exclude_vendored | ternary('true', 'false') }}
 MAX_FILE_SIZE = {{ gitea_repo_indexer_max_file_size }}
 {{ gitea_indexer_extra_config }}
-;
-;
 ; Queue (queue and queue.*)
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#queue-queue-and-queue
 [queue.issue_indexer]
 DATADIR = {{ gitea_home }}/indexers/issues.queue
 {{ gitea_queue_issue_indexer_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#security-security
 [security]
 INSTALL_LOCK = true
@@ -162,8 +139,6 @@ DISABLE_WEBHOOKS = {{ gitea_disable_webhooks | ternary('true', 'false') }}
 INTERNAL_TOKEN = {{ gitea_internal_token }}
 PASSWORD_CHECK_PWN = {{ gitea_password_check_pwn | ternary('true', 'false') }}
 {{ gitea_security_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#service-service
 [service]
 REGISTER_EMAIL_CONFIRM = {{ gitea_register_email_confirm | ternary('true', 'false') }}
@@ -187,16 +162,14 @@ DEFAULT_ORG_VISIBILITY = {{ gitea_default_org_visibility }}
 ALLOW_ONLY_INTERNAL_REGISTRATION = {{ gitea_allow_only_internal_registration | ternary('true', 'false') }}
 ALLOW_ONLY_EXTERNAL_REGISTRATION = {{ gitea_allow_only_external_registration | ternary('true', 'false') }}
 {{ gitea_service_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#mailer-mailer
 [mailer]
 ENABLED = {{ gitea_mailer_enabled | ternary('true', 'false') }}
 {% if gitea_mailer_enabled | bool %}
-{%     if gitea_mailer_use_client_cert | bool %}
+{%-     if gitea_mailer_use_client_cert | bool %}
 CLIENT_CERT_FILE = {{ gitea_mailer_client_cert_file }}
 CLIENT_KEY_FILE = {{ gitea_mailer_client_key_file }}
-{%     endif %}
+{%-     endif -%}
 PROTOCOL = {{ gitea_mailer_protocol }}
 SMTP_ADDR = {{ gitea_mailer_smtp_addr }}
 SMTP_PORT = {{ gitea_mailer_smtp_port }}
@@ -209,23 +182,17 @@ FROM = {{ gitea_mailer_from }}
 SUBJECT_PREFIX = {{ gitea_subject_prefix }}
 SEND_AS_PLAIN_TEXT = {{ gitea_mailer_send_as_plaintext | ternary('true', 'false') }}
 {{ gitea_mailer_extra_config }}
-;
 {% endif %}
-;
-;
+
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#session-session
 [session]
 PROVIDER = {{ gitea_session_provider }}
 PROVIDER_CONFIG = {{ gitea_session_provider_config }}
 {{ gitea_session_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#picture-picture
 [picture]
 AVATAR_UPLOAD_PATH = {{ gitea_home }}/data/avatars
 {{ gitea_picture_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#issue-and-pull-request-attachments-attachment
 [attachment]
 ENABLED = {{ gitea_attachment_enabled | ternary('true', 'false') }}
@@ -233,8 +200,6 @@ ALLOWED_TYPES = {{ gitea_attachment_types }}
 MAX_SIZE = {{ gitea_attachment_max_size }}
 PATH = {{ gitea_home }}/data/attachments
 {{ gitea_attachment_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#log-log
 [log]
 ROOT_PATH = {{ gitea_home }}/log
@@ -245,29 +210,21 @@ MODE = file
 {% endif %}
 LEVEL = {{ gitea_log_level }}
 {{ gitea_log_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#metrics-metrics
 [metrics]
 ENABLED = {{ gitea_metrics_enabled | ternary('true', 'false') }}
 TOKEN = {{ gitea_metrics_token }}
 {{ gitea_metrics_extra }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#oauth2-oauth2
 [oauth2]
 ENABLED = {{ gitea_oauth2_enabled | ternary('true', 'false') }}
 JWT_SECRET = {{ gitea_oauth2_jwt_secret }}
 {{ gitea_oauth2_extra_config }}
-;
-;
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#federation-federation
 [federation]
 ENABLED = {{ gitea_federation_enabled | ternary('true', 'false') }}
 SHARE_USER_STATISTICS = {{ gitea_federation_share_user_stats | ternary('true', 'false') }}
 {{ gitea_federation_extra }}
-;
-;
 ; Packages (packages)
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#packages-packages
 [packages]
@@ -276,8 +233,6 @@ ENABLED = {{ gitea_packages_enabled | ternary('true', 'false') }}
 CHUNKED_UPLOAD_PATH = {{ gitea_home }}/data/tmp/package-upload
 {{ gitea_packages_extra }}
 {% endif %}
-;
-;
 {% if gitea_lfs_server_enabled | bool %}
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#lfs-lfs
 [lfs]
@@ -286,8 +241,6 @@ SERVE_DIRECT = {{ gitea_lfs_serve_direct | ternary('true', 'false') }}
 PATH = {{ gitea_lfs_content_path }}
 {{ gitea_lfs_extra }}
 {% endif %}
-;
-;
 {% if gitea_actions_enabled | bool %}
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#actions-actions
 [actions]
@@ -295,8 +248,6 @@ ENABLED = {{ gitea_actions_enabled }}
 DEFAULT_ACTIONS_URL = {{ gitea_actions_default_actions_url }}
 {{ gitea_actions_extra }}
 {% endif %}
-;
-;
 ; Other (other)
 ; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#other-other
 [other]
@@ -304,8 +255,6 @@ SHOW_FOOTER_VERSION = {{ gitea_other_show_footer_version | ternary('true', 'fals
 SHOW_FOOTER_TEMPLATE_LOAD_TIME = {{ gitea_other_show_footer_template_load_time | ternary('true', 'false') }}
 ENABLE_SITEMAP = {{ gitea_other_enable_sitemap | ternary('true', 'false') }}
 ENABLE_FEED = {{ gitea_other_enable_feed | ternary('true', 'false') }}
-;
-;
-;
+
 ; Optional additional config
 {{ gitea_extra_config }}

--- a/templates/gitea.ini.j2
+++ b/templates/gitea.ini.j2
@@ -166,10 +166,10 @@ ALLOW_ONLY_EXTERNAL_REGISTRATION = {{ gitea_allow_only_external_registration | t
 [mailer]
 ENABLED = {{ gitea_mailer_enabled | ternary('true', 'false') }}
 {% if gitea_mailer_enabled | bool %}
-{%-     if gitea_mailer_use_client_cert | bool %}
+{%     if gitea_mailer_use_client_cert | bool %}
 CLIENT_CERT_FILE = {{ gitea_mailer_client_cert_file }}
 CLIENT_KEY_FILE = {{ gitea_mailer_client_key_file }}
-{%-     endif -%}
+{%     endif %}
 PROTOCOL = {{ gitea_mailer_protocol }}
 SMTP_ADDR = {{ gitea_mailer_smtp_addr }}
 SMTP_PORT = {{ gitea_mailer_smtp_port }}


### PR DESCRIPTION
fix #178 

- `recurse: true` causes issues as it applies the respective `mode` to all files in the subdirs. This conflicts with later tasks, which change them again, causing idempotence issues across runs
- Non-octal values for `mode` also cause idempotence issues. 

---

`gitea.ini` refactoring: due to changes in #184, idempotence of the "Configure gitea" step broke. On top, there were existing issues. For example, Ansible is stripping trailing whitespaces after comments with no text `;` in the `template` module. Yet, when restarting the systemd service, these are added back automatically (-> `; `), causing non-idempotence across runs.
Similar issues were introduced by blank lines within the jinja template. Depending on whether some "extra values" sections are defined or not, runs will become non-idempotent as the systemd service restart also alters such.

I've spent several hours trying different variants and I am quite certain that the combinations of changes in this PR are the most robust ones moving forward. Despite the first look, the template will still result in a config file with enough spacing between sections (due to the implicitly undefined "extra section" lines).

Example output:

```ini
; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#repository-repository
[repository]
ROOT = /opt/data/gitea/repos
FORCE_PRIVATE = false
DEFAULT_PRIVATE = private
MAX_CREATION_LIMIT = -1
DISABLE_HTTP_GIT = false
ENABLE_PUSH_CREATE_USER = false
ENABLE_PUSH_CREATE_ORG = false
DISABLED_REPO_UNITS = 
DEFAULT_REPO_UNITS = repo.code,repo.releases,repo.issues,repo.pulls
DISABLE_STARS = false
DEFAULT_BRANCH = main

; -> https://docs.gitea.com/next/administration/administration/config-cheat-sheet/#repository---upload-repositoryupload
[repository.upload]
ENABLED = true
TEMP_PATH = /opt/data/gitea/data/tmp/uploads
FILE_MAX_SIZE = 100
ALLOWED_TYPES = */*

; -> https://docs.gitea.com/next/administration/config-cheat-sheet/#ui-ui
[ui]
THEMES = forgejo-auto,forgejo-light,forgejo-dark,gitea-auto,gitea-light,gitea-dark,forgejo-auto-deuteranopia-protanopia,forgejo-light-deuteranopia-protanopia,forgejo-dark-deuteranopia-protanopia,forgejo-auto-tritanopia,forgejo-light-tritanopia,forgejo-dark-tritanopia
DEFAULT_THEME = forgejo-auto
SHOW_USER_EMAIL = true
```