### PR TITLE
feat: support source installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ It is advisable to define exactly which Forgejo release you want to install. See
 
 This is because the Forgejo project maintains both `stable` and `old stable` releases and the `latest` tag will refer to the _most recent release_ regardless of whether it is `stable` or `old stable`. This can lead to a situation where `latest` refers to an _older release_ than the version you have installed.
 
+### Installing from source
+
+Source installations should only be done if custom files changes should be incorporated during the binary build process or a (unreleased) bug fix is urgently needed.
+For repeated source installation builds, it is recommended to set `gitea_install_source_cleanup_build_dir: false` to persist a static clone.
+The installation logic dynamically installs the pinned versions of nodejs and go for the current develop branch, which are usually never than the versions provided by the system package managers.
+
+> [!WARNING]
+> Note that when installing from HEAD/non-tagged version, the database schema version will likely be bumped, preventing an easy downgrade to a tagged version afterwards.
+
 ### gitea update
 
 | variable name             | default value                              | description                                                                                                            |
@@ -93,6 +102,18 @@ This is because the Forgejo project maintains both `stable` and `old stable` rel
 | `gitea_backup_on_upgrade` | `false`                                    | Optionally a backup can be created with every update of gitea.                                                         |
 | `gitea_backup_location`   | `{{ gitea_home }}/backups/`                | Where to store the gitea backup if one is created with this role.                                                      |
 | `submodules_versioncheck` | `false`                                    | a simple version check that can prevent you from accidentally running an older version of this role. _(recommended)_   |
+
+### gitea installation
+
+| variable name                              | default value                                | description                                    |
+| ------------------------------------------ | -------------------------------------------- | ---------------------------------------------- |
+| `gitea_install_source_source_url`          | `https://github.com/go-gitea/gitea.git`      | Clone URL for Forge source                     |
+| `gitea_install_source_binary_name`         | `{{ gitea_fork }}`                           | Output binary name                             |
+| `gitea_install_source_binary_install_path` | `/usr/local/bin/`                            | Binary installation path                       |
+| `gitea_install_source_build_dir`           | `/tmp/{{ gitea_fork }}`                      | Build directory                                |
+| `gitea_install_source_cleanup_build_dir`   | `true`                                       | Whether to remove the build dir after building |
+| `gitea_install_source_apt_build_deps`      | `["sed", "make", "nodejs", "golang", "git"]` | APT Build dependencies                         |
+| `gitea_install_source_dnf_build_deps`      | `["sed", "make", "nodejs", "go", "git"]`     | DNF Build dependencies                         |
 
 ### gitea in the linux world
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -305,9 +305,11 @@ gitea_install_source_apt_build_deps:
   - nodejs
   - golang
   - git
+  - jq
 gitea_install_source_dnf_build_deps:
   - sed
   - make
   - nodejs
   - go
   - git
+  - jq

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -291,3 +291,23 @@ gitea_customize_files_path: "{{ gitea_custom_search }}/gitea_files/"
 # systemd hardening
 gitea_systemd_hardening_enable: true
 gitea_cgroups_restriction_enable: true
+
+# source installation
+# https://github.com/go-gitea/gitea.git or https://codeberg.org/forgejo/forgejo.git
+gitea_install_source_source_url: https://github.com/go-gitea/gitea.git
+gitea_install_source_binary_name: "{{ gitea_fork }}"
+gitea_install_source_binary_install_path: /usr/local/bin/
+gitea_install_source_build_dir: "/tmp/{{ gitea_fork }}"
+gitea_install_source_cleanup_build_dir: true
+gitea_install_source_apt_build_deps:
+  - sed
+  - make
+  - nodejs
+  - golang
+  - git
+gitea_install_source_dnf_build_deps:
+  - sed
+  - make
+  - nodejs
+  - go
+  - git

--- a/tasks/install_source.yml
+++ b/tasks/install_source.yml
@@ -147,7 +147,6 @@
         repo: "{{ gitea_install_source_source_url }}"
         dest: "{{ gitea_install_source_build_dir }}"
         version: "{{ gitea_install_source_source_ref }}"
-        # depth: 1
       register: _git_clone
       become: false
       until: _git_clone is succeeded

--- a/tasks/install_source.yml
+++ b/tasks/install_source.yml
@@ -1,0 +1,193 @@
+---
+- name: Source build dependencies
+  block:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Ensure curl is installed
+      ansible.builtin.package:
+        name: "curl"
+        state: present
+      when: '"curl" not in ansible_facts.packages'
+
+    - name: Source build dependencies - node
+      block:
+        - name: Query required node version from source
+          ansible.builtin.get_url:
+            url: >-
+              {% if gitea_fork == 'forgejo' %}
+              https://codeberg.org/forgejo/forgejo/raw/branch/forgejo/.forgejo/workflows/build-release.yml
+              {% else %}
+              https://raw.githubusercontent.com/go-gitea/gitea/main/.github/workflows/release-tag-rc.yml
+              {% endif %}
+            dest: "/tmp/{{ gitea_fork }}-build-release.yml"
+            mode: "0644"
+          register: build_file_download
+
+        - name: Extract Node.js version from build file
+          ansible.builtin.shell: |
+            grep -E "node-version:" "/tmp/{{ gitea_fork }}-build-release.yml" | head -n 1 | sed -E 's/.*node-version:\s*([0-9]+).*/\1/'
+          register: node_version_result
+          changed_when: false
+
+        - name: Set node version fact
+          ansible.builtin.set_fact:
+            node_version: "{{ node_version_result.stdout | trim }}"
+
+    - name: "Enable nodejs module stream - v{{ node_version }}"
+      when: ansible_os_family == "RedHat"
+      ansible.builtin.dnf:
+        name: "@nodejs:{{ node_version }}"
+        state: present
+      become: true
+
+    - name: "Configure node v{{ node_version }}"
+      when: ansible_os_family == 'Debian'
+      ansible.builtin.shell: |
+        curl -sL https://deb.nodesource.com/setup_{{ node_version }}.x | bash -
+
+    - name: Install apt build dependencies
+      become: true
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+      register: _install_build_deps
+      until: _install_build_deps is succeeded
+      retries: 5
+      delay: 2
+      loop: "{{ gitea_install_source_apt_build_deps }}"
+      when: 'item not in ansible_facts.packages and ansible_os_family == "Debian"'
+
+    - name: Install dnf build dependencies
+      become: true
+      ansible.builtin.dnf:
+        name: "{{ item }}"
+        state: present
+      register: _install_build_deps
+      until: _install_build_deps is succeeded
+      retries: 5
+      delay: 2
+      loop: "{{ gitea_install_source_dnf_build_deps }}"
+      when: 'item not in ansible_facts.packages and ansible_os_family == "RedHat"'
+
+    - name: Source build dependencies - go
+      block:
+        - name: Extract required go version for source build
+          ansible.builtin.get_url:
+            url: >-
+              {% if gitea_fork == 'forgejo' %}
+              https://codeberg.org/forgejo/forgejo/raw/branch/forgejo/go.mod
+              {% else %}
+              https://raw.githubusercontent.com/go-gitea/gitea/main/go.mod
+              {% endif %}
+            dest: "/tmp/{{ gitea_fork }}-go.mod"
+            mode: "0644"
+          register: build_go_mod_file_download
+
+        - name: Extract go version from go.mod file
+          ansible.builtin.shell: |
+            grep -E "^go [0-9]+\.[0-9]+(\.[0-9]+)?" "/tmp/{{ gitea_fork }}-go.mod" | head -n 1 | sed -E 's/go ([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/'
+          args:
+            executable: /bin/bash
+          register: go_version_result
+          changed_when: false
+
+        - name: Set go version fact
+          ansible.builtin.set_fact:
+            node_version: "{{ go_version_result.stdout | trim }}"
+          register: go_minor
+
+        - name: Query latest patch version for minor
+          ansible.builtin.shell: |
+            curl -s https://go.dev/dl/?mode=json |
+            jq -r '.[] | select(.version | startswith("go{{ go_version_result.stdout }}")) | .version' |
+            head -1 | sed 's/go//'
+          args:
+            executable: /bin/bash
+          register: go_version_query
+          changed_when: false
+
+        - name: Set Go version fact
+          ansible.builtin.set_fact:
+            go_version_source_build: "{{ go_version_query.stdout | trim }}"
+
+        - name: "Install required go version - v{{ go_version_source_build }}"
+          ansible.builtin.shell: |
+            # Check if Go version is already installed
+            export GOBIN_PATH="${GOPATH:-$HOME/go}/bin"
+            GO_ROOT="${HOME}/.go/go{{ go_version_source_build }}"
+
+            if [ -x "$GO_ROOT/bin/go" ]; then
+              echo "Go {{ go_version_source_build }} is already installed"
+            else
+              echo "Installing Go {{ go_version_source_build }}"
+              go install golang.org/dl/go{{ go_version_source_build }}@latest
+              $GOBIN_PATH/go{{ go_version_source_build }} download
+            fi
+          args:
+            executable: /bin/bash
+            creates: "{{ ansible_env.HOME }}/.go/go{{ go_version_source_build }}/bin/go"
+          register: go_install_result
+          changed_when: "'Installing Go' in go_install_result.stdout"
+
+- name: Build and install binary
+  block:
+    - name: Create build directory
+      ansible.builtin.file:
+        path: "{{ gitea_install_source_build_dir }}"
+        state: directory
+        mode: 0755
+      register: _build_dir
+      become: false
+
+    # full clone is necessary to properly determine local version string
+    - name: Clone git repository
+      ansible.builtin.git:
+        repo: "{{ gitea_install_source_source_url }}"
+        dest: "{{ gitea_install_source_build_dir }}"
+        version: "{{ gitea_install_source_source_ref }}"
+        # depth: 1
+      register: _git_clone
+      become: false
+      until: _git_clone is succeeded
+      retries: 3
+      delay: 5
+
+    - name: Build the binary
+      ansible.builtin.shell: |
+        export GOBIN_PATH="${GOPATH:-$HOME/go}/bin"
+        export GO="$GOBIN_PATH/go{{ go_version_source_build }}"
+        export TAGS="bindata"
+        $GO version
+        make build
+      args:
+        chdir: "{{ gitea_install_source_build_dir }}"
+        executable: /bin/bash
+      register: _build_result
+      become: false
+      changed_when: _build_result.rc == 0
+      failed_when: _build_result.rc != 0
+
+    - name: Propagate built binary
+      become: true
+      ansible.builtin.copy:
+        src: "{{ gitea_install_source_build_dir }}/gitea"
+        remote_src: true
+        dest: "{{ gitea_install_source_binary_install_path }}/{{ gitea_install_source_binary_name }}"
+        mode: 0755
+        owner: root
+        group: root
+      notify: systemctl restart gitea
+
+    - name: Remove binary after move
+      ansible.builtin.file:
+        path: "{{ gitea_install_source_binary_install_path }}{{ gitea_install_source_binary_name }}"
+        state: absent
+
+    - name: Clean up build directory
+      ansible.builtin.file:
+        path: "{{ gitea_install_source_build_dir }}"
+        state: absent
+      become: false
+      when: gitea_install_source_cleanup_build_dir | bool

--- a/tasks/install_source.yml
+++ b/tasks/install_source.yml
@@ -27,6 +27,7 @@
 
         - name: Extract Node.js version from build file
           ansible.builtin.shell: |
+            set -o pipefail
             grep -E "node-version:" "/tmp/{{ gitea_fork }}-build-release.yml" | head -n 1 | sed -E 's/.*node-version:\s*([0-9]+).*/\1/'
           register: node_version_result
           changed_when: false
@@ -42,10 +43,18 @@
         state: present
       become: true
 
-    - name: "Configure node v{{ node_version }}"
+    - name: Download NodeSource setup script
+      ansible.builtin.get_url:
+        url: "https://deb.nodesource.com/setup_{{ node_version }}.x"
+        dest: "/tmp/nodesource_setup.sh"
+        mode: "0755"
       when: ansible_os_family == 'Debian'
-      ansible.builtin.shell: |
-        curl -sL https://deb.nodesource.com/setup_{{ node_version }}.x | bash -
+
+    - name: Execute NodeSource setup script
+      ansible.builtin.command: bash /tmp/nodesource_setup.sh
+      register: nodesource_result
+      changed_when: nodesource_result.rc == 0 and "is already installed" not in nodesource_result.stdout
+      when: ansible_os_family == 'Debian'
 
     - name: Install apt build dependencies
       become: true
@@ -87,6 +96,7 @@
 
         - name: Extract go version from go.mod file
           ansible.builtin.shell: |
+            set -o pipefail
             grep -E "^go [0-9]+\.[0-9]+(\.[0-9]+)?" "/tmp/{{ gitea_fork }}-go.mod" | head -n 1 | sed -E 's/go ([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/'
           args:
             executable: /bin/bash
@@ -98,8 +108,10 @@
             node_version: "{{ go_version_result.stdout | trim }}"
           register: go_minor
 
+        # noqa: command-instead-of-module
         - name: Query latest patch version for minor
           ansible.builtin.shell: |
+            set -o pipefail
             curl -s https://go.dev/dl/?mode=json |
             jq -r '.[] | select(.version | startswith("go{{ go_version_result.stdout }}")) | .version' |
             head -1 | sed 's/go//'

--- a/tasks/install_source.yml
+++ b/tasks/install_source.yml
@@ -193,7 +193,7 @@
 
     - name: Remove binary after move
       ansible.builtin.file:
-        path: "{{ gitea_install_source_binary_install_path }}{{ gitea_install_source_binary_name }}"
+        path: "{{ gitea_install_source_build_dir }}{{ gitea_install_source_binary_name }}"
         state: absent
 
     - name: Clean up build directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
 - name: Gather versioning information
   ansible.builtin.include_tasks:
     file: "set_{{ gitea_fork | lower }}_version.yml"
+  when: gitea_version != "source"
 
 - name: Backup gitea before update
   ansible.builtin.include_tasks:
@@ -46,9 +47,15 @@
   ansible.builtin.include_tasks:
     file: "create_user.yml"
 
+- name: "Build and install {{ gitea_fork }} from source"
+  ansible.builtin.include_tasks:
+    file: "install_source.yml"
+  when: gitea_version == "source"
+
 - name: "Install or update {{ gitea_fork }}"
   ansible.builtin.include_tasks:
     file: "install_{{ gitea_fork | lower }}.yml"
+  when: gitea_version != "source"
 
 - name: Create directories
   ansible.builtin.include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
   ansible.builtin.include_tasks:
     file: "create_user.yml"
 
-- name: "Build and install {{ gitea_fork }} from source"
+- name: "Build and install from source [{{ gitea_fork }}]"
   ansible.builtin.include_tasks:
     file: "install_source.yml"
   when: gitea_version == "source"


### PR DESCRIPTION
To apply certain modifications, some files must be changed before building the binary (e.g. SVG icons). To support this procedure OOB, a new installation method which builds and installs from a given source ref is required.

The main challenge is to install the required build dep versions of nodejs and go dynamically, as the syslib ones are too old. 

This installation method should only be used if really necessary and when understanding the implications. I've added a note to the README.