### PR TITLE
fix: make `check_mode` agnostic to `gitea_version_check` var

### DIFF
--- a/tasks/install_forgejo.yml
+++ b/tasks/install_forgejo.yml
@@ -54,7 +54,7 @@
       become: false
       failed_when: _gitea_gpg_key_status.rc not in (0, 2)
 
-    - name: Print gpg key status on verbosity # noqa: H500
+    - name: Print gpg key status on verbosity  # noqa: H500
       ansible.builtin.debug:
         msg: "{{ _gitea_gpg_key_status.stdout }}"
         verbosity: 1

--- a/tasks/install_forgejo.yml
+++ b/tasks/install_forgejo.yml
@@ -22,7 +22,7 @@
       delay: 2
 
 - name: Install forgejo block
-  when: (not gitea_version_check | bool) or (not ansible_check_mode and (gitea_active_version.stdout != gitea_version_target))
+  when: not ansible_check_mode and (gitea_active_version.stdout != gitea_version_target)
   block:
     - name: Download forgejo archive
       ansible.builtin.get_url:
@@ -54,7 +54,7 @@
       become: false
       failed_when: _gitea_gpg_key_status.rc not in (0, 2)
 
-    - name: Print gpg key status on verbosity  # noqa: H500
+    - name: Print gpg key status on verbosity # noqa: H500
       ansible.builtin.debug:
         msg: "{{ _gitea_gpg_key_status.stdout }}"
         verbosity: 1
@@ -72,7 +72,7 @@
           ansible.builtin.copy:
             src: "{{ gitea_gpg_local_key }}"
             dest: /tmp/
-            mode: '0644'
+            mode: "0644"
           become: false
           when: gitea_gpg_local_key | length > 0
 

--- a/tasks/set_forgejo_version.yml
+++ b/tasks/set_forgejo_version.yml
@@ -94,7 +94,7 @@
     fail_msg: ERROR - Remote version is lower then current version!
   when: gitea_version == "latest" and gitea_active_version.stderr == "" | bool
 
-- name: Show Download URLs # noqa: H500
+- name: Show Download URLs  # noqa: H500
   when: not ansible_check_mode
   ansible.builtin.debug:
     msg: "{{ item }}"

--- a/tasks/set_forgejo_version.yml
+++ b/tasks/set_forgejo_version.yml
@@ -87,21 +87,6 @@
     gitea_forgejo_signed_url: "{{ gitea_forgejo_remote_tags_metadata.json | community.general.json_query(gitea_forgejo_query_signed) }}"
   when: not ansible_check_mode
 
-- name: "Set a example forgejo download link if in check mode"
-  ansible.builtin.set_fact:
-    gitea_forgejo_dl_url: ["https://{{ gitea_forgejo_repo }}/attachments/a00333ad-250a-4d30-a764-9a37fb24f419"]
-  when: ansible_check_mode
-
-- name: "Set a example forgejo checksum link if in check mode"
-  ansible.builtin.set_fact:
-    gitea_forgejo_checksum: "f8c71464d1b250bf022eaa3df270c810950904ceb71da5cefc7ec24a034a4c87"
-  when: ansible_check_mode
-
-- name: "Set a example forgejo checksum link if in check mode"
-  ansible.builtin.set_fact:
-    gitea_forgejo_signed_url: ["https://{{ gitea_forgejo_repo }}/attachments/ae5e50c6-e86e-4202-b95f-f142e8138e2f"]
-  when: ansible_check_mode
-
 - name: "Assert that remote version is higher"
   ansible.builtin.assert:
     that:
@@ -109,7 +94,8 @@
     fail_msg: ERROR - Remote version is lower then current version!
   when: gitea_version == "latest" and gitea_active_version.stderr == "" | bool
 
-- name: Show Download URLs  # noqa: H500
+- name: Show Download URLs # noqa: H500
+  when: not ansible_check_mode
   ansible.builtin.debug:
     msg: "{{ item }}"
     verbosity: 1


### PR DESCRIPTION
fix #163 

The helper vars in `tasks/set_forgejo_version.yml` are not needed and by removing `gitea_version_check` in "Install forgejo block", the block is actually always skipped in `check_mode` (which seems to be the desired state anyhow).