### PR TITLE
Check data locations for correctness before applying permissions.

### DIFF
--- a/tasks/directory.yml
+++ b/tasks/directory.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Create config and data directory"
+- name: "Check {{ item }}"
   become: true
   ansible.builtin.file:
     path: "{{ item }}"
@@ -7,18 +7,12 @@
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
     mode: "0755"
-  loop:
-    - "{{ gitea_user_home }}"
-    - "{{ gitea_home }}"
-    - "{{ gitea_home }}/data"
-    - "{{ gitea_custom }}"
-    - "{{ gitea_custom }}/https"
-    - "{{ gitea_custom }}/mailer"
-    - "{{ gitea_home }}/indexers"
-    - "{{ gitea_home }}/log"
-    - "{{ gitea_repository_root }}"
+  check_mode: true
+  diff: true
+  register: _gitea_dir_check
 
-- name: "Create config and data directory"
+- name: "Create {{ item }}"  # noqa no-handler execute immediately.
+  when: _gitea_dir_check.changed
   become: true
   ansible.builtin.file:
     path: "{{ item }}"
@@ -26,5 +20,3 @@
     owner: "{{ gitea_user }}"
     group: "{{ gitea_group }}"
     mode: "0755"
-  loop:
-    - "{{ gitea_configuration_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,17 @@
 - name: Create directories
   ansible.builtin.include_tasks:
     file: "directory.yml"
+  loop:
+    - "{{ gitea_user_home }}"
+    - "{{ gitea_home }}"
+    - "{{ gitea_home }}/data"
+    - "{{ gitea_custom }}"
+    - "{{ gitea_custom }}/https"
+    - "{{ gitea_custom }}/mailer"
+    - "{{ gitea_home }}/indexers"
+    - "{{ gitea_home }}/log"
+    - "{{ gitea_repository_root }}"
+    - "{{ gitea_configuration_path }}"
 
 - name: Setup gitea systemd service
   ansible.builtin.include_tasks:


### PR DESCRIPTION
Locations are now checked, only applying changes if required; preventing failures due to remote data mounts and UID/GID squashing.

Fixes:
* https://github.com/roles-ansible/ansible_role_gitea/issues/201